### PR TITLE
Fix issue #174: Unable to load subtitle files with uppercase extension (e.g. ASS)

### DIFF
--- a/src/subtitles/GFN.cpp
+++ b/src/subtitles/GFN.cpp
@@ -157,7 +157,7 @@ void GetSubFileNames(CString fn, CAtlArray<CString>& paths, CString load_ext_lis
             {
                 const CString& fn = sl.GetNext(pos);
                 int l = fn.ReverseFind('.');
-                CString ext = fn.Mid(l+1);
+                CString ext = fn.Mid(l+1).MakeLower();
                 int ext_order = ext_support.ext_support_order(ext);
                 if (ext_order>-1)
                 {


### PR DESCRIPTION
http://code.google.com/p/xy-vsfilter/issues/detail?id=174
