### PR TITLE
Fix override tag argument splitting

### DIFF
--- a/src/subtitles/RTS.cpp
+++ b/src/subtitles/RTS.cpp
@@ -2356,12 +2356,14 @@ bool CRenderedTextSubtitle::ParseSSATag( AssTagList *assTags, const CStringW& st
 
                 CStringW::PCXSTR newstart = FindChar(param_start, param_end, L',');
                 CStringW::PCXSTR newend = FindChar(param_start, param_end, L'\\');
-                if(newstart > param_start && newstart < newend)
+                if(newstart < newend)
                 {
-                    newstart = FastSkipWhiteSpaceRight(param_start, newstart);
-                    CStringW s(param_start, newstart - param_start);
-
-                    if(!s.IsEmpty()) params.Add(s);
+                    if(newstart > param_start)
+                    {
+                        newend = FastSkipWhiteSpaceRight(param_start, newstart);
+                        CStringW s(param_start, newend - param_start);
+                        if(!s.IsEmpty()) params.Add(s);
+                    }
                     param_start = newstart + 1;
                 }
                 else if(param_start<param_end)


### PR DESCRIPTION
This fixes two bugs introduced all the way back in 9aad0c99aae8fcaec9f23572ecfd859a1f30bf09, where a “bug” is defined as behaviour that’s both obviously silly and incompatible with guliverkli2 VSFilter 2.39 and below. (Thankfully, all incompatible behaviour I’ve noticed is also obviously silly.)

Artificial broken sample: https://gist.github.com/astiob/046395b5d99e4b0336fd
- Currently, if an empty (whitespace-only) argument is followed by a comma, that comma and everything that follows it, including any other commas and backslashes, is lumped together and treated as a single long argument (which is always non-empty because it includes the comma). Instead, the comma should be skipped.
- Currently, if a non-empty (non-whitespace-only) argument that is followed by a comma contains some trailing whitespace, the string pointer is reset to the first whitespace character + 1. This is either the comma or another whitespace character, in which case it is skipped in the next iteration of the loop. Ultimately, the pointer ends up at the comma. This, in turn, activates the first bug. Instead, the pointer should be reset to the comma + 1.
  
  I suppose fixing the first bug is enough to ensure correct behaviour, as the comma will then be skipped. But why spend extra time looping around and walking the whitespace again when the fix is so easy?

I don’t know how your branches work, so I just did this on the seemingly most up-to-date branch. This should easily cherry-pick/rebase onto any other branch.

I’ll confess I haven’t tested this, but I have at least reread the code a bunch of times. :)
