### PR TITLE
SubRenderIntf: Use libass to render ASS subtitles

### DIFF
--- a/include/ass.hpp
+++ b/include/ass.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include "ass.h"
+
+struct ASS_LibraryDeleter
+{
+    void operator()(ASS_Library* p) { if (p) ass_library_done(p); }
+};
+
+struct ASS_RendererDeleter
+{
+    void operator()(ASS_Renderer* p) { if (p) ass_renderer_done(p); }
+};
+
+struct ASS_TrackDeleter
+{
+    void operator()(ASS_Track* p) { if (p) ass_free_track(p); }
+};

--- a/src/filters/transform/vsfilter/DirectVobSubPropPage.cpp
+++ b/src/filters/transform/vsfilter/DirectVobSubPropPage.cpp
@@ -1901,6 +1901,8 @@ CXySubFilterMorePPage::CXySubFilterMorePPage(LPUNKNOWN pUnk, HRESULT* phr)
     BindControl(IDC_AUTORELOAD, m_autoreload);
     BindControl(IDC_INSTANTUPDATE, m_instupd);
 
+    BindControl(IDC_CHECKBOX_VS_ASS_RENDERING, m_vsassrendering);
+
     BindControl(IDC_COMBO_COLOR_SPACE, m_combo_yuv_matrix);
     BindControl(IDC_COMBO_YUV_RANGE, m_combo_yuv_range);
     BindControl(IDC_COMBO_RGB_LEVEL, m_combo_rgb_level);
@@ -2037,6 +2039,9 @@ void CXySubFilterMorePPage::UpdateObjectData(bool fSave)
         hr = m_pDirectVobSub->put_SubtitleReloader(m_fReloaderDisabled);
         CHECK_N_LOG(hr, "Failed to set option");
 
+        hr = m_pDirectVobSubXy->XySetBool(DirectVobSubXyOptions::BOOL_VS_ASS_RENDERING, m_fVSAssRendering);
+        CHECK_N_LOG(hr, "Failed to set option");
+
         hr = m_pDirectVobSubXy->XySetInt(DirectVobSubXyOptions::INT_YUV_RANGE, m_yuv_range);
         CHECK_N_LOG(hr, "Failed to set option");
         hr = m_pDirectVobSubXy->XySetInt(DirectVobSubXyOptions::INT_COLOR_SPACE, m_yuv_matrix);
@@ -2072,6 +2077,9 @@ void CXySubFilterMorePPage::UpdateObjectData(bool fSave)
         hr = m_pDirectVobSubXy->XyGetBool(DirectVobSubXyOptions::BOOL_ALLOW_MOVING, &m_fAllowMoving);
         CHECK_N_LOG(hr, "Failed to get option");
         hr = m_pDirectVobSub->get_SubtitleReloader(&m_fReloaderDisabled);
+        CHECK_N_LOG(hr, "Failed to get option");
+
+        hr = m_pDirectVobSubXy->XyGetBool(DirectVobSubXyOptions::BOOL_VS_ASS_RENDERING, &m_fVSAssRendering);
         CHECK_N_LOG(hr, "Failed to get option");
 
         hr = m_pDirectVobSubXy->XyGetInt(DirectVobSubXyOptions::INT_YUV_RANGE, &m_yuv_range);
@@ -2129,6 +2137,7 @@ void CXySubFilterMorePPage::UpdateControlData(bool fSave)
         m_fAllowMoving = !!m_allowmoving.GetCheck();
         m_fReloaderDisabled = !m_autoreload.GetCheck();
 
+        m_fVSAssRendering = !!m_vsassrendering.GetCheck();
 
         if (m_combo_yuv_range.GetCurSel() != CB_ERR)
         {
@@ -2227,6 +2236,8 @@ void CXySubFilterMorePPage::UpdateControlData(bool fSave)
         m_allowmoving.SetCheck(m_fAllowMoving);
         m_autoreload.SetCheck(!m_fReloaderDisabled);
         m_instupd.SetCheck(!!theApp.GetProfileInt(ResStr(IDS_R_GENERAL), ResStr(IDS_RG_INSTANTUPDATE), 1));
+
+        m_vsassrendering.SetCheck(m_fVSAssRendering);
 
         if( m_yuv_range != CDirectVobSub::YuvRange_Auto &&
             m_yuv_range != CDirectVobSub::YuvRange_PC &&

--- a/src/filters/transform/vsfilter/DirectVobSubPropPage.h
+++ b/src/filters/transform/vsfilter/DirectVobSubPropPage.h
@@ -291,12 +291,14 @@ class CXySubFilterMorePPage : public CDVSBasePPage
     int m_yuv_matrix, m_yuv_range, m_rgb_level;
     SIZE m_layout_size;
 
-    bool m_fHideSubtitles, m_fAllowMoving, m_fReloaderDisabled;
+    bool m_fHideSubtitles, m_fAllowMoving, m_fReloaderDisabled, m_fVSAssRendering;
     bool m_render_to_original_video_size;
 
     int  m_cache_size, m_auto_cache_size;
 
     CButton m_hidesub, m_allowmoving, m_autoreload, m_instupd;
+
+    CButton m_vsassrendering;
 
     CSpinButtonCtrl m_path_cache, m_scanline_cache, m_overlay_no_blur_cache, m_overlay_cache;
 

--- a/src/filters/transform/vsfilter/IDirectVobSubXy.h
+++ b/src/filters/transform/vsfilter/IDirectVobSubXy.h
@@ -147,6 +147,8 @@ namespace DirectVobSubXyOptions
 
         BOOL_ALLOW_MOVING,
 
+        BOOL_VS_ASS_RENDERING,
+
         OPTION_COUNT
     };
     struct ColorSpaceOpt
@@ -246,6 +248,8 @@ namespace DirectVobSubXyOptions
         {XyOptionsImpl::OPTION_TYPE_BOOL  , XyOptionsImpl::OPTION_MODE_RW, BOOL_HIDE_SUBTITLES},
         {XyOptionsImpl::OPTION_TYPE_BOOL  , XyOptionsImpl::OPTION_MODE_RW, BOOL_ALLOW_MOVING},
 
+        {XyOptionsImpl::OPTION_TYPE_BOOL  , XyOptionsImpl::OPTION_MODE_RW, BOOL_VS_ASS_RENDERING},
+
         {XyOptionsImpl::OPTION_TYPE_SIZE  , XyOptionsImpl::OPTION_MODE_READ, SIZE_ORIGINAL_VIDEO},
         {XyOptionsImpl::OPTION_TYPE_SIZE  , XyOptionsImpl::OPTION_MODE_READ, SIZE_ASS_PLAY_RESOLUTION},
         {XyOptionsImpl::OPTION_TYPE_SIZE  , XyOptionsImpl::OPTION_MODE_RW, SIZE_USER_SPECIFIED_LAYOUT_SIZE},
@@ -335,6 +339,8 @@ namespace DirectVobSubXyOptions
         {XyOptionsImpl::OPTION_TYPE_BOOL  , XyOptionsImpl::OPTION_MODE_RW, BOOL_HIDE_TRAY_ICON},
         {XyOptionsImpl::OPTION_TYPE_BOOL  , XyOptionsImpl::OPTION_MODE_RW, BOOL_HIDE_SUBTITLES},
         {XyOptionsImpl::OPTION_TYPE_BOOL  , XyOptionsImpl::OPTION_MODE_RW, BOOL_ALLOW_MOVING},
+
+        {XyOptionsImpl::OPTION_TYPE_BOOL  , XyOptionsImpl::OPTION_MODE_RW, BOOL_VS_ASS_RENDERING},
 
         {XyOptionsImpl::OPTION_TYPE_INT   , XyOptionsImpl::OPTION_MODE_RW, INT_MAX_BITMAP_COUNT},
         {XyOptionsImpl::OPTION_TYPE_BOOL  , XyOptionsImpl::OPTION_MODE_RW, BOOL_COMBINE_BITMAPS},

--- a/src/filters/transform/vsfilter/SubFrame.cpp
+++ b/src/filters/transform/vsfilter/SubFrame.cpp
@@ -1,0 +1,141 @@
+/*
+ *   Copyright(C) 2016-2017 Blitzker
+ *
+ *   This program is free software : you can redistribute it and / or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "stdafx.h"
+#include "SubFrame.h"
+#include <ppl.h>
+
+namespace
+{
+    inline POINT GetRectPos(RECT rect)
+    {
+        return {rect.left, rect.top};
+    }
+
+    inline SIZE GetRectSize(RECT rect)
+    {
+        return {rect.right - rect.left, rect.bottom - rect.top};
+    }
+}
+
+SubFrame::SubFrame(RECT rect, ULONGLONG id, ASS_Image* image)
+    : CUnknown("", nullptr)
+    , m_rect(rect)
+    , m_id(id)
+    , m_pixelsRect{}
+{
+    Flatten(image);
+}
+
+STDMETHODIMP SubFrame::NonDelegatingQueryInterface(REFIID riid, void** ppv)
+{
+    if (riid == __uuidof(ISubRenderFrame))
+        return GetInterface(static_cast<ISubRenderFrame*>(this), ppv);
+
+    return __super::NonDelegatingQueryInterface(riid, ppv);
+}
+
+STDMETHODIMP SubFrame::GetOutputRect(RECT* outputRect)
+{
+    CheckPointer(outputRect, E_POINTER);
+    *outputRect = m_rect;
+    return S_OK;
+}
+
+STDMETHODIMP SubFrame::GetClipRect(RECT* clipRect)
+{
+    CheckPointer(clipRect, E_POINTER);
+    *clipRect = m_rect;
+    return S_OK;
+}
+
+STDMETHODIMP SubFrame::GetBitmapCount(int* count)
+{
+    CheckPointer(count, E_POINTER);
+    *count = (m_pixels ? 1 : 0);
+    return S_OK;
+}
+
+STDMETHODIMP SubFrame::GetBitmap(int index, ULONGLONG* id, POINT* position, SIZE* size, LPCVOID* pixels, int* pitch)
+{
+    if (index != 0) return E_INVALIDARG;
+
+    if (!id && !position && !size && !pixels && !pitch)
+        return S_FALSE;
+
+    if (id)
+        *id = m_id;
+    if (position)
+        *position = GetRectPos(m_pixelsRect);
+    if (size)
+        *size = GetRectSize(m_pixelsRect);
+    if (pixels)
+        *pixels = m_pixels.get();
+    if (pitch)
+        *pitch = size->cx * 4;
+
+    return S_OK;
+}
+
+void SubFrame::Flatten(ASS_Image* image)
+{
+    if (image)
+    {
+        for (auto i = image; i != nullptr; i = i->next)
+        {
+            RECT rect1 = m_pixelsRect;
+            RECT rect2 = {i->dst_x, i->dst_y, i->dst_x + i->w, i->dst_y + i->h};
+            UnionRect(&m_pixelsRect, &rect1, &rect2);
+        }
+
+        const POINT pixelsPoint = GetRectPos(m_pixelsRect);
+        const SIZE pixelsSize = GetRectSize(m_pixelsRect);
+        m_pixels = std::make_unique<uint32_t[]>(pixelsSize.cx * pixelsSize.cy);
+
+        for (auto i = image; i != nullptr; i = i->next)
+        {
+            concurrency::parallel_for(0, i->h, [&](int y)
+            {
+                for (int x = 0; x < i->w; ++x)
+                {
+                    uint32_t& dest = m_pixels[(i->dst_y + y - pixelsPoint.y) * pixelsSize.cx +
+                                              (i->dst_x + x - pixelsPoint.x)];
+
+                    uint32_t destA = (dest & 0xff000000) >> 24;
+
+                    uint32_t srcA = i->bitmap[y * i->stride + x] * (0xff - (i->color & 0x000000ff));
+                    srcA >>= 8;
+
+                    uint32_t compA = 0xff - srcA;
+
+                    uint32_t outA = srcA + ((destA * compA) >> 8);
+
+                    uint32_t outR = ((i->color & 0xff000000) >> 8) * srcA + (dest & 0x00ff0000) * compA;
+                    outR >>= 8;
+
+                    uint32_t outG = ((i->color & 0x00ff0000) >> 8) * srcA + (dest & 0x0000ff00) * compA;
+                    outG >>= 8;
+
+                    uint32_t outB = ((i->color & 0x0000ff00) >> 8) * srcA + (dest & 0x000000ff) * compA;
+                    outB >>= 8;
+
+                    dest = (outA << 24) + (outR & 0x00ff0000) + (outG & 0x0000ff00) + (outB & 0x000000ff);
+                }
+            }, concurrency::static_partitioner());
+        }
+    }
+}

--- a/src/filters/transform/vsfilter/SubFrame.h
+++ b/src/filters/transform/vsfilter/SubFrame.h
@@ -1,0 +1,50 @@
+/*
+ *   Copyright(C) 2016-2017 Blitzker
+ *
+ *   This program is free software : you can redistribute it and / or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <ass.h>
+
+class SubFrame final
+    : public CUnknown
+    , public ISubRenderFrame
+{
+public:
+
+    SubFrame(RECT rect, ULONGLONG id, ASS_Image* image);
+
+    DECLARE_IUNKNOWN;
+
+    // CUnknown
+    STDMETHODIMP NonDelegatingQueryInterface(REFIID riid, void** ppv) override;
+
+    // ISubRenderFrame
+    STDMETHODIMP GetOutputRect(RECT* outputRect) override;
+    STDMETHODIMP GetClipRect(RECT* clipRect) override;
+    STDMETHODIMP GetBitmapCount(int* count) override;
+    STDMETHODIMP GetBitmap(int index, ULONGLONG* id, POINT* position, SIZE* size, LPCVOID* pixels, int* pitch) override;
+
+private:
+
+    void Flatten(ASS_Image* image);
+
+    const RECT m_rect;
+    const ULONGLONG m_id;
+
+    std::unique_ptr<uint32_t[]> m_pixels;
+    RECT m_pixelsRect;
+};

--- a/src/filters/transform/vsfilter/VSFilter.rc
+++ b/src/filters/transform/vsfilter/VSFilter.rc
@@ -459,6 +459,8 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,127,132,10
     EDITTEXT        IDC_EDIT_CACHE_SIZE,22,72,40,14,ES_AUTOHSCROLL,WS_EX_RIGHT
     RTEXT           "Cache Size(MB)",IDC_LABLE_CACHE_SIZE,14,60,57,8
+    CONTROL         "Use VSFilter (legacy) ASS implementation",IDC_CHECKBOX_VS_ASS_RENDERING,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,266,224,10
 END
 
 

--- a/src/filters/transform/vsfilter/resource.h
+++ b/src/filters/transform/vsfilter/resource.h
@@ -243,14 +243,16 @@
 #define IDC_COLORSHAD                   1066
 #define IDS_RG_ALLOWMOVING              1070
 #define IDC_CHECKBOX_ALLOW_MOVING       1071
+#define IDS_RG_VSASSRENDERING           1072
+#define IDC_CHECKBOX_VS_ASS_RENDERING   1073
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        338
+#define _APS_NEXT_RESOURCE_VALUE        339
 #define _APS_NEXT_COMMAND_VALUE         32770
-#define _APS_NEXT_CONTROL_VALUE         343
+#define _APS_NEXT_CONTROL_VALUE         344
 #define _APS_NEXT_SYMED_VALUE           210
 #endif
 #endif

--- a/src/filters/transform/vsfilter/xy_sub_filter.cpp
+++ b/src/filters/transform/vsfilter/xy_sub_filter.cpp
@@ -1207,8 +1207,18 @@ STDMETHODIMP XySubFilter::RequestFrame( REFERENCE_TIME start, REFERENCE_TIME sto
             }
 
             ass_set_frame_size(sts->m_renderer.get(), m_xy_rect_opt[RECT_SUBTITLE_TARGET].right, m_xy_rect_opt[RECT_SUBTITLE_TARGET].bottom);
-            sub_render_frame = new SubFrame(m_xy_rect_opt[RECT_SUBTITLE_TARGET], m_consumerLastId, ass_render_frame(sts->m_renderer.get(), sts->m_track.get(), start / 10000, 0));
-            m_consumerLastId++;
+
+            int changed = 1;
+            ASS_Image *image = ass_render_frame(sts->m_renderer.get(), sts->m_track.get(), start / 10000, &changed);
+            if (!changed && m_last_frame) {
+                sub_render_frame = m_last_frame;
+            }
+            else 
+            {
+                m_consumerLastId++;
+                sub_render_frame = new SubFrame(m_xy_rect_opt[RECT_SUBTITLE_TARGET], m_consumerLastId, image);
+                m_last_frame = sub_render_frame;
+            }
         }
         CAutoLock cAutoLock(&m_csConsumer);
         hr = m_consumer->DeliverFrame(start, stop, context, sub_render_frame);

--- a/src/filters/transform/vsfilter/xy_sub_filter.h
+++ b/src/filters/transform/vsfilter/xy_sub_filter.h
@@ -4,6 +4,7 @@
 #include "DirectVobSub.h"
 #include "SubRenderIntf.h"
 #include "SubRenderOptionsImpl.h"
+#include <ass.hpp>
 
 class CDirectVobSubFilter;
 
@@ -83,6 +84,8 @@ private:
     void SetRgbOutputLevel();
     bool Open();
 
+    void LoadASSFont(IPin* pPin, ASS_Library* ass, ASS_Renderer* renderer);
+
     void UpdateSubtitle(bool fApplyDefStyle = true);
     void SetSubtitle(ISubStream* pSubStream, bool fApplyDefStyle = true);
     void InvalidateSubtitle(REFERENCE_TIME rtInvalidate = -1, DWORD_PTR nSubtitleId = -1);
@@ -128,6 +131,8 @@ private:
     ISubStream *m_curSubStream;
     CInterfaceList<ISubStream> m_pSubStreams;
     CAtlList<bool> m_fIsSubStreamEmbeded;
+
+    ULONGLONG m_consumerLastId;
 
     // critical section protecting all
     CCritSec m_csFilter;

--- a/src/filters/transform/vsfilter/xy_sub_filter.h
+++ b/src/filters/transform/vsfilter/xy_sub_filter.h
@@ -160,6 +160,8 @@ private:
 
     REFERENCE_TIME m_last_requested;
 
+    CComPtr<ISubRenderFrame> m_last_frame;
+
     bool m_workaround_mpc_hc;//enable workaround for MPC-HC to prevent be removed from the graph
 
     bool m_disconnect_entered;

--- a/src/filters/transform/vsfilter/xy_sub_filter.vcxproj
+++ b/src/filters/transform/vsfilter/xy_sub_filter.vcxproj
@@ -80,6 +80,7 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="StyleEditorDialog.cpp" />
+    <ClCompile Include="SubFrame.cpp" />
     <ClCompile Include="SubRenderOptionsImpl.cpp" />
     <ClCompile Include="SubtitleInputPin2.cpp" />
     <ClCompile Include="Systray.cpp" />
@@ -100,6 +101,7 @@
     <ClInclude Include="resource.h" />
     <ClInclude Include="StdAfx.h" />
     <ClInclude Include="StyleEditorDialog.h" />
+    <ClInclude Include="SubFrame.h" />
     <ClInclude Include="SubRenderOptionsImpl.h" />
     <ClInclude Include="SubtitleInputPin2.h" />
     <ClInclude Include="Systray.h" />

--- a/src/filters/transform/vsfilter/xy_sub_filter.vcxproj.filters
+++ b/src/filters/transform/vsfilter/xy_sub_filter.vcxproj.filters
@@ -71,6 +71,9 @@
     <ClCompile Include="auto_load_helper.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="SubFrame.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DirectVobSub.h">
@@ -131,6 +134,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="auto_load_helper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SubFrame.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/subtitles/STS.h
+++ b/src/subtitles/STS.h
@@ -25,6 +25,7 @@
 #include <wxutil.h>
 #include "TextFile.h"
 #include "GFN.h"
+#include <ass.hpp>
 
 typedef enum {TIME, FRAME} tmode; // the meaning of STSEntry::start/end
 
@@ -291,6 +292,17 @@ public:
     friend bool OpenMicroDVD(CTextFile* file, CSimpleTextSubtitle& ret, int CharSet);
 private:
     bool CopyStyles(const CSTSStyleMap& styles, bool fAppend = false);
+
+public:
+    IPin* m_pPin;
+    bool LoadASSFile();
+    bool LoadASSTrack(char* data, int size);
+    void UnloadASS();
+    bool m_assloaded;
+    bool m_assfontloaded;
+    std::unique_ptr<ASS_Library, ASS_LibraryDeleter> m_ass;
+    std::unique_ptr<ASS_Renderer, ASS_RendererDeleter> m_renderer;
+    std::unique_ptr<ASS_Track, ASS_TrackDeleter> m_track;
 };
 
 extern BYTE   CharSetList[];

--- a/src/subtitles/SubtitleInputPin.cpp
+++ b/src/subtitles/SubtitleInputPin.cpp
@@ -277,6 +277,10 @@ STDMETHODIMP CTextSubtitleInputPinHepler::Receive( IMediaSample* pSample )
                     m_pRTS->Add(stse.str, true, (int)(tStart / 10000), (int)(tStop / 10000), 
                         stse.style, stse.actor, stse.effect, stse.marginRect, stse.layer, stse.readorder);
                 }
+
+                if (m_pRTS->m_assloaded) {
+                    ass_process_chunk(m_pRTS->m_track.get(), (char*)pData, pSample->GetSize(), tStart / 10000, (tStop - tStart) / 10000);
+                }
             }
             else
             {
@@ -522,6 +526,9 @@ STDMETHODIMP_(CSubtitleInputPinHelper*) CSubtitleInputPin::CreateHelper( const C
 
                 pRTS->Open(mt1.pbFormat + dwOffset, mt1.cbFormat - dwOffset, DEFAULT_CHARSET, pRTS->m_name);
             }
+
+            pRTS->m_pPin = pReceivePin;
+            pRTS->LoadASSTrack((char*)mt.Format() + psi->dwOffset, mt.FormatLength() - psi->dwOffset);
             ret = DEBUG_NEW CTextSubtitleInputPinHepler(pRTS, m_mt);
         }
         else if(mt.subtype == MEDIASUBTYPE_SSF)


### PR DESCRIPTION
It supports both internal subtitles and external subtitles. It also supports "Open a subtitle file". 

It is quite stable at the moment I believe. I haven't notice any issue yet.

I also added a toggle in "More" page. Users can use toggle to switch between libass and VSFilter rendering method in real time. It is not a permanent property. The property will get reset to default (libass) each time subtitle renderer restarts. 

![image](https://user-images.githubusercontent.com/11585141/52546156-df27e980-2d71-11e9-852d-8e650ff46c62.png)

concurrency function is used in SubFrame::Flatten function currently. I am not sure about its performance on lower end platform. It does work fine for me, though. I will probably need to compare its performance with OpenMP's. 
@Cyberbeing Could you please test how it works on your environment? 

Binary: x64: https://github.com/jesec/xy-VSFilter/commit/8c23283e3a5f410f24c3ec6373d5f40736fb7d3a
[XySubFilter_git-8c23283_x64.zip](https://github.com/Cyberbeing/xy-VSFilter/files/2849910/XySubFilter_git-8c23283_x64.zip)

Note that you probably need to handle some includes (notably libass) by yourself. Those are not included in this change due to environment differences. libass can be grabbed via vcpkg or you can include it into src\thirdparty. 

And IMO we probably should jump the major version (3 to 4) for this. 