### PR TITLE
fix: filter operation when changing play rate.

### DIFF
--- a/src/filters/transform/vsfilter/DirectVobSubFilter.h
+++ b/src/filters/transform/vsfilter/DirectVobSubFilter.h
@@ -208,6 +208,9 @@ private:
 
 	//xy TIMING
 	long m_time_rasterization, m_time_alphablt;
+	
+	bool m_bExternalSubtitle = false;
+	std::vector<ISubStream*> m_ExternalSubstreams;
 };
 
 /* The "auto-loading" version */


### PR DESCRIPTION
when I speed up the video, the internal subtitles of mkv are doubly accelerated.

fixes port from https://github.com/v0lt/VSFilter/commit/13a2b5367bde8f6935b08618c3f56b1a249c13c9 and https://github.com/v0lt/VSFilter/commit/94f82394c265bce7f57fba703d67b176506cf93c